### PR TITLE
Allow single objects to force its locale

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lost_in_translations (1.4.2)
+    lost_in_translations (1.4.3)
       i18n (~> 0.7)
 
 GEM
@@ -88,4 +88,4 @@ DEPENDENCIES
   sqlite3 (= 1.3.11)
 
 BUNDLED WITH
-   1.12.5
+   1.15.3

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ class CreateUsers < ActiveRecord::Migration
     User.create \
       title: 'Cavaleiro',
       first_name: 'Joao',
-      last_name: 'Neve'
+      last_name: 'Neve',
       translation_data: {
         en: { first_name: 'Jon', last_name: 'Snow' },
         fr: { first_name: 'Jean', last_name: 'Neige' }
@@ -128,7 +128,69 @@ I18n.locale = :fr
 @user.title # returns nil
 ```
 
-## 3) Instalation
+## 3) Forcing locales
+
+There are many cases when you'll need to translate only a part of your data,
+specially if this part is returned in a list of translated data.
+
+For those cases you only have to define the field (virtual or persisted)
+`force_locale` with one valid locale:
+
+```ruby
+class User < ActiveRecord::Base
+  include LostInTranslations
+
+  translate :title, :first_name
+end
+
+User.create(
+  title: 'Cavaleiro',
+  first_name: 'Joao',
+  last_name: 'Neve',
+  force_locale: nil,
+  translation_data: {
+    en: { first_name: 'Jon', last_name: 'Snow' },
+    fr: { first_name: 'Jean', last_name: 'Neige' }
+  }
+)
+
+User.create(
+  title: 'Cavaleiro',
+  first_name: 'Joao',
+  last_name: 'Neve',
+  force_locale: 'fr'
+  translation_data: {
+    en: { first_name: 'Jon', last_name: 'Snow' },
+    fr: { first_name: 'Jean', last_name: 'Neige' }
+  }
+)
+
+User.create(
+  title: 'Cavaleiro',
+  first_name: 'Joao',
+  last_name: 'Neve',
+  force_locale: 'en'
+  translation_data: {
+    en: { first_name: 'Jon', last_name: 'Snow' },
+    fr: { first_name: 'Jean', last_name: 'Neige' }
+  }
+)
+
+I18n.locale = :pt
+
+User.all.each do |user|
+  puts user.name
+end
+
+# It'll automatically output:
+# Joao
+# Jean
+# Jon
+
+```
+
+
+## 4) Instalation
 
 Add this to your Gemfile:
 ```
@@ -147,7 +209,7 @@ LostInTranslations.reload
 ```
 Because Rails starts with a set of **I18n.available_locales** different from when it finished loading and **LostInTranslations** needs to redefine new methods for those new locales in your classes.
 
-## 4) F.A.Q.
+## 5) F.A.Q.
 
 - [I18n.available_locales as changed, how do I recreate the new translation methods?](https://github.com/Streetbees/lost-in-translations/wiki/Redefining-translation-methods)
 - [Your "translation_data" method (in all of your objects) is not called "translation_data"](https://github.com/Streetbees/lost-in-translations/wiki/translation_data-configuration-version-1)

--- a/lib/lost_in_translations.rb
+++ b/lib/lost_in_translations.rb
@@ -16,7 +16,12 @@ module LostInTranslations
   end
 
   def self.config
-    @config ||= Config.new('translation_data', Translator::Base, nil, 'force_locale')
+    @config ||= Config.new(
+      'translation_data',
+      Translator::Base,
+      nil,
+      'force_locale'
+    )
   end
 
   def self.translate(*args)

--- a/lib/lost_in_translations.rb
+++ b/lib/lost_in_translations.rb
@@ -16,7 +16,7 @@ module LostInTranslations
   end
 
   def self.config
-    @config ||= Config.new('translation_data', Translator::Base)
+    @config ||= Config.new('translation_data', Translator::Base, nil, 'force_locale')
   end
 
   def self.translate(*args)

--- a/lib/lost_in_translations/base.rb
+++ b/lib/lost_in_translations/base.rb
@@ -27,10 +27,16 @@ module LostInTranslations
 
     module ClassMethods
       attr_writer :translation_data_field
+      attr_writer :force_locale_field
 
       def translation_data_field
         @translation_data_field ||
           LostInTranslations.config.translation_data_field
+      end
+
+      def force_locale_field
+        @force_locale_field ||
+          LostInTranslations.config.force_locale_field
       end
 
       def translation_fields

--- a/lib/lost_in_translations/config.rb
+++ b/lib/lost_in_translations/config.rb
@@ -1,4 +1,4 @@
 module LostInTranslations
   Config = Struct.new \
-    :translation_data_field, :translator, :fallback_to_default_locale
+    :translation_data_field, :translator, :fallback_to_default_locale, :force_locale_field
 end

--- a/lib/lost_in_translations/config.rb
+++ b/lib/lost_in_translations/config.rb
@@ -1,4 +1,5 @@
 module LostInTranslations
   Config = Struct.new \
-    :translation_data_field, :translator, :fallback_to_default_locale, :force_locale_field
+    :translation_data_field, :translator, :fallback_to_default_locale,
+    :force_locale_field
 end

--- a/lib/lost_in_translations/translator/base.rb
+++ b/lib/lost_in_translations/translator/base.rb
@@ -1,9 +1,8 @@
 module LostInTranslations
   module Translator
     class Base
-      def self.translate(object, field, locale)
-
-        locale = check_forcing_locale(object, locale)
+      def self.translate(object, field, original_locale)
+        locale = check_forcing_locale(object, original_locale)
 
         data = translation_data(object)
 
@@ -50,7 +49,9 @@ module LostInTranslations
         force_locale_field = object.class.force_locale_field
 
         if object.respond_to?(force_locale_field)
-          return object.send(force_locale_field)
+          force_locale = object.send(force_locale_field)
+
+          return force_locale unless force_locale.to_s.length < 2
         end
 
         locale

--- a/lib/lost_in_translations/translator/base.rb
+++ b/lib/lost_in_translations/translator/base.rb
@@ -2,6 +2,9 @@ module LostInTranslations
   module Translator
     class Base
       def self.translate(object, field, locale)
+
+        locale = check_forcing_locale(object, locale)
+
         data = translation_data(object)
 
         translations = data[locale.to_sym] || data[locale.to_s] || {}
@@ -41,6 +44,16 @@ module LostInTranslations
         end
 
         translation_data_field
+      end
+
+      def self.check_forcing_locale(object, locale)
+        force_locale_field = object.class.force_locale_field
+
+        if object.respond_to?(force_locale_field)
+          return object.send(force_locale_field)
+        end
+
+        locale
       end
     end
   end

--- a/lib/lost_in_translations/version.rb
+++ b/lib/lost_in_translations/version.rb
@@ -1,3 +1,3 @@
 module LostInTranslations
-  VERSION = '1.4.2'.freeze
+  VERSION = '1.4.3'.freeze
 end

--- a/spec/lost_in_translations/base_spec.rb
+++ b/spec/lost_in_translations/base_spec.rb
@@ -66,4 +66,45 @@ describe LostInTranslations::Base do
       end
     end
   end
+
+  describe '.force_locale_field =' do
+    context 'when forces a locale' do
+      before do
+        @user_class = Struct.new(:first_name, :last_name, :title, :force_locale) do
+          include LostInTranslations::Base
+
+          self.translation_data_field = :translation_json
+
+          def translation_json
+            @translation_json ||= {
+              'en-GB' => { first_name: 'Jon', last_name: 'Snow', title: 'King of the North' },
+              'fr' => { first_name: 'Jean', last_name: 'Neige' }
+            }
+          end
+        end
+
+        LostInTranslations.define_translation_methods(@user_class, :first_name, :title)
+
+        @user = @user_class.new('Joao', 'Neve', 'Rei do Norte' , 'fr')
+      end
+
+      it 'LostInTranslations.translate must return a forced translation' do
+        expect(LostInTranslations.translate(@user, :first_name, 'en-GB')).to \
+          eq 'Jean'
+      end
+
+      it 'calling a field not translated, must return the original data' do
+        I18n.with_locale('en-GB') do
+          expect(@user.last_name).to eq 'Neve'
+        end
+      end
+
+      context 'and the translation data does not contain results' do
+        it 'LostInTranslations.translate must return nil' do
+          expect(LostInTranslations.translate(@user, :title, :de)).to \
+            be_nil
+        end
+      end
+    end
+  end
 end

--- a/spec/lost_in_translations/base_spec.rb
+++ b/spec/lost_in_translations/base_spec.rb
@@ -70,22 +70,34 @@ describe LostInTranslations::Base do
   describe '.force_locale_field =' do
     context 'when forces a locale' do
       before do
-        @user_class = Struct.new(:first_name, :last_name, :title, :force_locale) do
+        @user_class = Struct.new(
+          :first_name,
+          :last_name,
+          :title,
+          :force_locale) do
           include LostInTranslations::Base
 
           self.translation_data_field = :translation_json
 
           def translation_json
             @translation_json ||= {
-              'en-GB' => { first_name: 'Jon', last_name: 'Snow', title: 'King of the North' },
+              'en-GB' => {
+                first_name: 'Jon',
+                last_name: 'Snow',
+                title: 'King of the North'
+              },
               'fr' => { first_name: 'Jean', last_name: 'Neige' }
             }
           end
         end
 
-        LostInTranslations.define_translation_methods(@user_class, :first_name, :title)
+        LostInTranslations.define_translation_methods(
+          @user_class,
+          :first_name,
+          :title
+        )
 
-        @user = @user_class.new('Joao', 'Neve', 'Rei do Norte' , 'fr')
+        @user = @user_class.new('Joao', 'Neve', 'Rei do Norte', 'fr')
       end
 
       it 'LostInTranslations.translate must return a forced translation' do


### PR DESCRIPTION
These changes aims to allow the objects that uses this gem to decide for themselves if they are going to be translated by using the global variable (I18n.locale) or force any locale stored on the field `force_locale` if it exists or is defined with any valid locale.

